### PR TITLE
fix(pt/animesgratis): Fixed episode parser for films

### DIFF
--- a/src/pt/animesgratis/build.gradle
+++ b/src/pt/animesgratis/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.Bakashi'
     themePkg = 'dooplay'
     baseUrl = 'https://bakashi.tv'
-    overrideVersionCode = 10
+    overrideVersionCode = 11
 }
 
 apply from: "$rootDir/common.gradle"


### PR DESCRIPTION
Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
