### PR TITLE
FRAnime: JSON title is missing fix

### DIFF
--- a/src/fr/franime/build.gradle
+++ b/src/fr/franime/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'FrAnime'
     extClass = '.FrAnime'
-    extVersionCode = 11
+    extVersionCode = 12
     isNsfw = true
 }
 apply from: "$rootDir/common.gradle"

--- a/src/fr/franime/src/eu/kanade/tachiyomi/animeextension/fr/franime/dto/FrAnimeDto.kt
+++ b/src/fr/franime/src/eu/kanade/tachiyomi/animeextension/fr/franime/dto/FrAnimeDto.kt
@@ -68,7 +68,7 @@ data class Season(
 
 @Serializable
 data class Episode(
-    @SerialName("title") val title: String,
+    @SerialName("title") val title: String = "!No Title!",
     @SerialName("lang") val languages: EpisodeLanguages,
 )
 


### PR DESCRIPTION
Not the best fix but it counts

Closes #74 

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] ~~Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions~~
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x]  `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] ~~Have removed `web_hi_res_512.png` when adding a new extension~~
